### PR TITLE
Suppress lint errors for RTL strings

### DIFF
--- a/app/src/main/res/layout/fragment_support_blank_card.xml
+++ b/app/src/main/res/layout/fragment_support_blank_card.xml
@@ -18,14 +18,16 @@
         card_view:cardCornerRadius="@dimen/card_corner_radius"
         card_view:cardElevation="@dimen/card_elevation">
 
+        <!--suppress NewApi -->
         <TextView
             android:layout_width="fill_parent"
             android:layout_height="@dimen/card_label_height"
             android:background="@color/cardLabel"
             android:gravity="center|start"
-            android:paddingEnd="@dimen/card_label_left_margin"
-            android:paddingLeft="@dimen/card_label_left_margin"
-            android:paddingStart="@dimen/card_label_left_margin"
+            android:paddingLeft="@dimen/card_label_start_margin"
+            android:paddingRight="@dimen/card_label_end_margin"
+            android:paddingStart="@dimen/card_label_start_margin"
+            android:paddingEnd="@dimen/card_label_end_margin"
             android:text="@string/hello_blank_fragment"
             android:textColor="@color/cardLabelText"
             android:textSize="@dimen/card_label_text_size" />

--- a/app/src/main/res/layout/fragment_support_progress_card.xml
+++ b/app/src/main/res/layout/fragment_support_progress_card.xml
@@ -17,14 +17,16 @@
         card_view:cardCornerRadius="@dimen/card_corner_radius"
         card_view:cardElevation="@dimen/card_elevation">
 
+        <!--suppress NewApi -->
         <TextView
             android:layout_width="fill_parent"
             android:layout_height="@dimen/card_label_height"
             android:background="@color/cardLabel"
             android:gravity="center|start"
-            android:paddingEnd="@dimen/card_label_left_margin"
-            android:paddingLeft="@dimen/card_label_left_margin"
-            android:paddingStart="@dimen/card_label_left_margin"
+            android:paddingLeft="@dimen/card_label_start_margin"
+            android:paddingRight="@dimen/card_label_end_margin"
+            android:paddingStart="@dimen/card_label_start_margin"
+            android:paddingEnd="@dimen/card_label_end_margin"
             android:text="@string/progress"
             android:textColor="@color/cardLabelText"
             android:textSize="@dimen/card_label_text_size" />

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -14,7 +14,8 @@
     <dimen name="card_corner_radius">4dp</dimen>
     <dimen name="card_elevation">4dp</dimen>
     <dimen name="card_label_height">60dp</dimen>
-    <dimen name="card_label_left_margin">10dp</dimen>
+    <dimen name="card_label_start_margin">10dp</dimen>
+    <dimen name="card_label_end_margin">10dp</dimen>
     <dimen name="card_label_text_size">20sp</dimen>
     <dimen name="card_separator_height">2dp</dimen>
     <dimen name="card_separator_margin">20dp</dimen>


### PR DESCRIPTION
We use both left/right and start/end, so there is no issue here and
we can safely suppress this warning.