### PR TITLE
Suppress UnusedAttribute warnings

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -6,6 +6,7 @@
     <uses-permission android:name="android.permission.READ_CONTACTS" />
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
 
+    <!--suppress UnusedAttribute-->
     <application
         android:name=".CeaselessApplication"
         android:allowBackup="true"

--- a/app/src/main/res/layout/fragment_support_progress_card.xml
+++ b/app/src/main/res/layout/fragment_support_progress_card.xml
@@ -42,6 +42,7 @@
                 android:gravity="center"
                 android:text="@string/prayed_for_text" />
 
+            <!--suppress UnusedAttribute-->
             <ProgressBar
                 android:id="@+id/prayer_progress"
                 style="?android:attr/progressBarStyleHorizontal"


### PR DESCRIPTION
We are safe if our tints or RTL settings don't get read, so we
can suppress these warnings.