### PR TITLE
Disable failing lint checks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ android:
 
 script:
   - gradle build
+  - gradle check
 
 notifications:
   slack:

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -34,7 +34,19 @@ android {
         }
     }
     lintOptions {
-        abortOnError false
+        disable 'PrivateResource',
+                'MissingTranslation',
+                'AllowBackup',
+                'UnusedResources',
+                'UselessLeaf',
+                'UselessParent',
+                'IconColors',
+                'IconLocation',
+                'IconDensities',
+                'ButtonStyle',
+                'HardcodedText',
+                'RtlSymmetry',
+                'RtlHardcoded'
     }
 
     packagingOptions {


### PR DESCRIPTION
Additionally, this change requires Travis to pass the lint checks, so
that errors don't get reintroduced.