### PR TITLE
Fixing bug when going through contacts list once you cannot restart. …

### DIFF
--- a/app/src/main/java/org/theotech/ceaselessandroid/person/PersonManagerImpl.java
+++ b/app/src/main/java/org/theotech/ceaselessandroid/person/PersonManagerImpl.java
@@ -96,7 +96,9 @@ public class PersonManagerImpl implements PersonManager {
                 .equalTo(Person.Column.IGNORED, false)
                 .equalTo(Person.Column.PRAYED, false)
                 .findAllSorted(Person.Column.LAST_PRAYED);
-        handleAllPrayedFor(results);
+
+        handleAllPrayedFor(results, n);
+
         List<Person> allPeople = getShuffledListOfAllPeople(results);
         if (allPeople.size() < 1) {
             return people;
@@ -141,14 +143,17 @@ public class PersonManagerImpl implements PersonManager {
         return allPeople;
     }
 
-    private void handleAllPrayedFor(RealmResults<Person> results) throws AlreadyPrayedForAllContactsException {
+    private void handleAllPrayedFor(RealmResults<Person> results, int n) throws AlreadyPrayedForAllContactsException {
         // if all people are prayed for, then reset and throw exception
-        if (getNumPeople() > 0 && results.size() == 0) {
-            // Reset all the prayed flags
+        if (getNumPeople() > 0 && results.size() < n) {
+            // we can't check just for result size
+
+            // Reset prayed to false for each person that had the prayed flag set
             realm.beginTransaction();
             RealmResults<Person> resultsToReset = realm.where(Person.class)
                     .equalTo(Person.Column.ACTIVE, true)
                     .equalTo(Person.Column.IGNORED, false)
+                    .equalTo(Person.Column.PRAYED, true)
                     .findAll();
             for (int i = 0; i < resultsToReset.size(); i++) {
                 resultsToReset.get(i).setPrayed(false);

--- a/build.gradle
+++ b/build.gradle
@@ -8,8 +8,8 @@ buildscript {
         }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.5.0'
-        classpath 'com.google.gms:google-services:1.5.0-beta2'
+        classpath 'com.android.tools.build:gradle:2.1.0'
+        classpath 'com.google.gms:google-services:2.1.0'
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sat Oct 03 10:16:40 PDT 2015
+#Fri May 13 09:46:27 PDT 2016
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.10-all.zip


### PR DESCRIPTION
Fixing one part of bug #78 when prayed through all contacts and user cannot restart list...updating gradle and android studio. Asking @uberx to test it on his device since I'm not able to test this change.

This does not necessarily remove the "Not Implemented Yet" cards, which is ideally what we want to do...it may succeed in doing so since it clears out the prayed flags ahead of time though.

Ideally we'd want to congratulate the user on praying for their contacts.