### PR TITLE
 Upgrading realm.io from 0.84.2 to 4.3.3

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -19,6 +19,7 @@ apply plugin: 'findbugs'
 apply plugin: 'io.fabric'
 apply plugin: 'pmd'
 apply plugin: 'com.onesignal.androidsdk.onesignal-gradle-plugin'
+apply plugin: 'realm-android'
 
 repositories {
     maven { url 'https://maven.fabric.io/public' }
@@ -90,14 +91,12 @@ dependencies {
     compile 'com.squareup.okhttp:okhttp:2.4.0'
     compile 'com.squareup.picasso:picasso:2.5.2'
     compile 'fr.avianey.com.viewpagerindicator:library:2.4.1@aar'
-    compile 'io.realm:realm-android:0.84.2'
     compile 'jp.wasabeef:picasso-transformations:2.1.1'
     compile 'com.google.android.gms:play-services-analytics:11.8.0'
     compile 'com.commonsware.cwac:merge:1.1.+'
     compile "com.android.support:support-v4:$supportlib_version"
     compile 'com.onesignal:OneSignal:[3.7.1, 3.99.99]'
 
-    annotationProcessor 'io.realm:realm-android:0.84.2'
     annotationProcessor 'com.jakewharton:butterknife-compiler:8.8.1'
 }
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -35,8 +35,8 @@ android {
         applicationId "org.theotech.ceaselessandroid"
         minSdkVersion 15
         targetSdkVersion 25
-        versionCode 16
-        versionName "1.0.3"
+        versionCode 17
+        versionName "1.0.4"
         manifestPlaceholders = [onesignal_app_id: "3d054882-fde3-4bee-bf8e-723087fc3536",
                                 // Project number pulled from dashboard, local value is ignored.
                                 onesignal_google_project_number: "REMOTE"]

--- a/app/src/main/java/org/theotech/ceaselessandroid/CeaselessApplication.java
+++ b/app/src/main/java/org/theotech/ceaselessandroid/CeaselessApplication.java
@@ -65,8 +65,9 @@ public class CeaselessApplication extends Application {
         RealmConfiguration config = new RealmConfiguration.Builder()
                 .name(Constants.REALM_FILE_NAME)
                 .schemaVersion(Constants.SCHEMA_VERSION)
-                .deleteRealmIfMigrationNeeded()
                 .build();
+        // ajma: removing .deleteRealmIfMigrationNeeded() because this results in a silent data loss.
+        //       We'd rather it crash (rollout with 5% first to see) and then patch so we don't loose people's data.
         Realm.setDefaultConfiguration(config);
 
     }

--- a/app/src/main/java/org/theotech/ceaselessandroid/CeaselessApplication.java
+++ b/app/src/main/java/org/theotech/ceaselessandroid/CeaselessApplication.java
@@ -61,7 +61,8 @@ public class CeaselessApplication extends Application {
         Iconify.with(new FontAwesomeModule());
 
         // realm (added by T. Kopp on 2/2/16)
-        RealmConfiguration config = new RealmConfiguration.Builder(this)
+        Realm.init(this);
+        RealmConfiguration config = new RealmConfiguration.Builder()
                 .name(Constants.REALM_FILE_NAME)
                 .schemaVersion(Constants.SCHEMA_VERSION)
                 .deleteRealmIfMigrationNeeded()

--- a/app/src/main/java/org/theotech/ceaselessandroid/cache/LocalDailyCacheManagerImpl.java
+++ b/app/src/main/java/org/theotech/ceaselessandroid/cache/LocalDailyCacheManagerImpl.java
@@ -145,14 +145,13 @@ public class LocalDailyCacheManagerImpl implements CacheManager {
 
         LocalCacheData realmCacheData = getRealmCacheData();
         if (realmCacheData == null) {
-            realmCacheData = realm.createObject(LocalCacheData.class);
+            realmCacheData = realm.createObject(LocalCacheData.class, generateCreationDate());
         }
         populateCacheData(realmCacheData, newCacheData);
         realm.commitTransaction();
     }
 
     private void populateCacheData(LocalCacheData realmCacheData, LocalCacheDataPOJO newCacheData) {
-        realmCacheData.setCreationDate(generateCreationDate());
         if (newCacheData.getPersonIdsToPrayFor() != null) {
             List<String> personIdsToPrayFor = newCacheData.getPersonIdsToPrayFor();
             RealmList<RealmString> managedPersonIdsToPrayFor = new RealmList<>();

--- a/app/src/main/java/org/theotech/ceaselessandroid/note/NoteManagerImpl.java
+++ b/app/src/main/java/org/theotech/ceaselessandroid/note/NoteManagerImpl.java
@@ -16,6 +16,7 @@ import java.util.Date;
 import java.util.List;
 import java.util.UUID;
 
+import io.realm.Case;
 import io.realm.Realm;
 import io.realm.RealmList;
 
@@ -55,10 +56,9 @@ public class NoteManagerImpl implements NoteManager {
     @Override
     public void addNote(String title, String text, List<PersonPOJO> personPOJOs) {
         realm.beginTransaction();
-        Note note = realm.createObject(Note.class);
+        Note note = realm.createObject(Note.class, UUID.randomUUID().toString());
         note.setCreationDate(new Date());
         note.setLastUpdatedDate(new Date());
-        note.setId(UUID.randomUUID().toString());
         note.setActive(true);
         if (title != null) {
             note.setTitle(title);
@@ -102,7 +102,7 @@ public class NoteManagerImpl implements NoteManager {
     @Override
     public void removeNote(String noteId) {
         realm.beginTransaction();
-        getRealmNote(noteId).removeFromRealm();
+        getRealmNote(noteId).deleteFromRealm();
         realm.commitTransaction();
     }
 
@@ -131,7 +131,7 @@ public class NoteManagerImpl implements NoteManager {
     public List<NotePOJO> queryNotesByText(String query) {
         List<Note> results = realm.where(Note.class)
                 .equalTo(Note.Column.ACTIVE, true)
-                .contains(Note.Column.TEXT, query, false)
+                .contains(Note.Column.TEXT, query, Case.INSENSITIVE)
                 .findAllSorted(Note.Column.LAST_UPDATED_DATE);
         return RealmUtils.toNotePOJOs(results);
     }

--- a/app/src/main/java/org/theotech/ceaselessandroid/person/PersonManagerImpl.java
+++ b/app/src/main/java/org/theotech/ceaselessandroid/person/PersonManagerImpl.java
@@ -32,6 +32,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Random;
 
+import io.realm.Case;
 import io.realm.Realm;
 import io.realm.RealmList;
 import io.realm.RealmQuery;
@@ -358,8 +359,7 @@ public class PersonManagerImpl implements PersonManager {
 
                     if (person == null) {
 
-                        person = realm.createObject(Person.class);
-                        person.setId(id);
+                        person = realm.createObject(Person.class, id);
                         person.setName(name);
                         person.setSource(CONTACTS_SOURCE);
                         person.setActive(true);
@@ -406,7 +406,7 @@ public class PersonManagerImpl implements PersonManager {
                     // update daily cache with new ids if any persons selected for today are affected
                     peopleWithUpdatedIds.add(Pair.create(p.getId(), matchingContact));
                     // cleanup the obsolete contact (must be after we've update the cache)
-                    p.removeFromRealm();
+                    p.deleteFromRealm();
                 } else {
                     Log.v(TAG, "Marking this contact inactive because it no longer exists on the phone.");
                     p.setActive(false);
@@ -488,7 +488,7 @@ public class PersonManagerImpl implements PersonManager {
     @Override
     public List<PersonPOJO> queryPeopleByName(String query) {
         List<PersonPOJO> people = RealmUtils.toPersonPOJOs(realm.where(Person.class)
-                .contains(Person.Column.NAME, query, false)
+                .contains(Person.Column.NAME, query, Case.INSENSITIVE)
                 .equalTo(Person.Column.ACTIVE, true)
                 .findAllSorted(Person.Column.NAME));
         return people;

--- a/app/src/main/java/org/theotech/ceaselessandroid/realm/LocalCacheData.java
+++ b/app/src/main/java/org/theotech/ceaselessandroid/realm/LocalCacheData.java
@@ -3,12 +3,13 @@ package org.theotech.ceaselessandroid.realm;
 import io.realm.RealmList;
 import io.realm.RealmObject;
 import io.realm.annotations.PrimaryKey;
+import io.realm.annotations.Required;
 
 /**
  * Created by uberx on 10/4/15.
  */
 public class LocalCacheData extends RealmObject {
-    @PrimaryKey
+    @PrimaryKey @Required
     private String creationDate;
     private String scriptureCitation;
     private String scriptureText;

--- a/app/src/main/java/org/theotech/ceaselessandroid/realm/Note.java
+++ b/app/src/main/java/org/theotech/ceaselessandroid/realm/Note.java
@@ -5,13 +5,14 @@ import java.util.Date;
 import io.realm.RealmList;
 import io.realm.RealmObject;
 import io.realm.annotations.PrimaryKey;
+import io.realm.annotations.Required;
 
 /**
  * Created by uberx on 10/11/2015.
  */
 public class Note extends RealmObject {
 
-    @PrimaryKey
+    @PrimaryKey @Required
     private String id;
     private Date creationDate;
     private Date lastUpdatedDate;

--- a/app/src/main/java/org/theotech/ceaselessandroid/realm/Person.java
+++ b/app/src/main/java/org/theotech/ceaselessandroid/realm/Person.java
@@ -5,6 +5,7 @@ import java.util.Date;
 import io.realm.RealmList;
 import io.realm.RealmObject;
 import io.realm.annotations.PrimaryKey;
+import io.realm.annotations.Required;
 
 /**
  * Created by Ben Johnson on 10/3/15.
@@ -12,7 +13,7 @@ import io.realm.annotations.PrimaryKey;
 
 public class Person extends RealmObject {
 
-    @PrimaryKey
+    @PrimaryKey @Required
     private String id;
     private String name;
     private String source;

--- a/build.gradle
+++ b/build.gradle
@@ -16,6 +16,7 @@ buildscript {
         classpath 'com.google.gms:google-services:3.0.0'
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
+        classpath "io.realm:realm-gradle-plugin:4.3.3"
     }
 }
 


### PR DESCRIPTION
Good summary of breaking changes here: https://stackoverflow.com/questions/39971209/upgrade-realm-in-an-android-project/39974275#39974275

Main ones that affect ceaseless are
- change in createObject requiring the primarykey to be included.
- primarykey need be explicitly marked as required now. I'm marking them so the db schema doesn't need to be changed, otherwise we'd have to do a migration to make the keys optional.
